### PR TITLE
Upgrade to .net version 6 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+          
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,14 @@
 name: Build
 on:
   push:
+    paths-ignore:
+      - '**.md'
     branches:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**.md'
 jobs:
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ This creates the https certificate.
 In the root folder, run ``dotnet test``. This command will try to find all test projects associated with the sln file.
 If you are using Visual Studio, you can also acess the Test Menu and open the Test Explorer, where you can see all tests and run all of them or one specifically. 
 
+## Authentication
+In this project, some routes requires authentication/authorization. For that, you will have to use the ``api/user/authenticate`` route to obtain the JWT.
+As default, you have two users, Admin and normal user.
+- Normal user: 
+	- email: user@boilerplate.com
+	- password: userpassword
+- Admin:
+	- email: admin@boilerplate.com
+	- password: adminpassword
+
+After that, you can pass the jwt on the lock (if using swagger) or via the Authorization header on a http request.
+
 # This project contains:
 - SwaggerUI
 - EntityFramework

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,6 +14,7 @@ services:
       - ASPNETCORE_URLS=https://+:443;http://+:80
       - ASPNETCORE_Kestrel__Certificates__Default__Password=yourpassword
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx
+      - ConnectionStrings__DefaultConnection=Server=mssql;Database=Heroes;User=sa;Password=Yourpassword123
     ports:
       - "5000:80"
       - "5001:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
     image: mcr.microsoft.com/mssql/server:2017-latest
     container_name: mssql
     networks:
-      - localdev  
+      - localdev
+    volumes:
+      - sqlvolume:/var/opt/mssql      
   boilerplate-api:
     entrypoint: ["./wait-for.sh", "mssql:1433", "-t", "120", "--", "dotnet", "Boilerplate.Api.dll"]
     build:
@@ -25,3 +27,6 @@ services:
       - localdev
     volumes:
       - ./etc/wait-for.sh:/app/wait-for.sh
+
+volumes:
+  sqlvolume:

--- a/src/Boilerplate.Api/Boilerplate.Api.csproj
+++ b/src/Boilerplate.Api/Boilerplate.Api.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />

--- a/src/Boilerplate.Api/Boilerplate.Api.csproj
+++ b/src/Boilerplate.Api/Boilerplate.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>83093e71-d34c-405d-b8eb-442525b137fc</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
@@ -14,25 +14,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.6">
+    <PackageReference Include="AutoMapper" Version="11.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Boilerplate.Api/Dockerfile
+++ b/src/Boilerplate.Api/Dockerfile
@@ -1,13 +1,17 @@
 ##See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 #
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-RUN apt-get -q update && apt-get -qy install netcat
+# Install cultures (same approach as Alpine SDK image)
+RUN apk add --no-cache icu-libs
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+# Disable the invariant mode (set in base image)
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["src/Boilerplate.Api/Boilerplate.Api.csproj", "src/Boilerplate.Api/"]
 COPY ["src/Boilerplate.Application/Boilerplate.Application.csproj", "src/Boilerplate.Application/"]

--- a/src/Boilerplate.Api/appsettings.json
+++ b/src/Boilerplate.Api/appsettings.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=mssql;Database=master;User=sa;Password=Yourpassword123"
+    "DefaultConnection": "Server=127.0.0.1;Database=Heroes;User=sa;Password=Yourpassword123"
   },
   "TokenConfiguration": {
     "Secret": "yoursecret12345123120319230",

--- a/src/Boilerplate.Application/Boilerplate.Application.csproj
+++ b/src/Boilerplate.Application/Boilerplate.Application.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper" Version="11.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Boilerplate.Domain.Core/Boilerplate.Domain.Core.csproj
+++ b/src/Boilerplate.Domain.Core/Boilerplate.Domain.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Boilerplate.Domain/Boilerplate.Domain.csproj
+++ b/src/Boilerplate.Domain/Boilerplate.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Boilerplate.Infrastructure/Boilerplate.Infrastructure.csproj
+++ b/src/Boilerplate.Infrastructure/Boilerplate.Infrastructure.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Boilerplate.Infrastructure/Configuration/UserConfiguration.cs
+++ b/src/Boilerplate.Infrastructure/Configuration/UserConfiguration.cs
@@ -18,14 +18,14 @@ namespace Boilerplate.Infrastructure.Configuration
             builder.HasData(
                 new User
                 {
-                    Id = Guid.NewGuid(),
+                    Id = new Guid("687d9fd5-2752-4a96-93d5-0f33a49913c6"),
                     Email = "admin@boilerplate.com",
                     Role = "Admin",
                     Password = BC.HashPassword("adminpassword")
                 },
                 new User
                 {
-                    Id = Guid.NewGuid(),
+                    Id = new Guid("6648c89f-e894-42bb-94f0-8fd1059c86b4"),
                     Email = "user@boilerplate.com",
                     Role = "User",
                     Password = BC.HashPassword("userpassword")

--- a/tests/Boilerplate.Api.IntegrationTests/Boilerplate.Api.IntegrationTests.csproj
+++ b/tests/Boilerplate.Api.IntegrationTests/Boilerplate.Api.IntegrationTests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="Bogus" Version="34.0.1" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Faker.Net" Version="1.5.138" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="FluentAssertions" Version="6.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Boilerplate.Api.IntegrationTests/Helpers/Utilities.cs
+++ b/tests/Boilerplate.Api.IntegrationTests/Helpers/Utilities.cs
@@ -67,6 +67,7 @@ namespace Boilerplate.Api.IntegrationTests.Helpers
             var connectionString = $"Data Source={Guid.NewGuid()}.db";
             return factory.WithWebHostBuilder(builder =>
             {
+                builder.UseEnvironment("Testing");
                 builder.ConfigureServices(services =>
                 {
                     var descriptor = services.SingleOrDefault(

--- a/tests/Boilerplate.Api.UnitTests/Boilerplate.Api.UnitTests.csproj
+++ b/tests/Boilerplate.Api.UnitTests/Boilerplate.Api.UnitTests.csproj
@@ -1,27 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="Bogus" Version="34.0.1" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FluentAssertions" Version="6.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Boilerplate.Api.UnitTests/HeroRepositoryTests.cs
+++ b/tests/Boilerplate.Api.UnitTests/HeroRepositoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Bogus;
 using Boilerplate.Domain.Entities;
 using Boilerplate.Domain.Entities.Enums;
 using Boilerplate.Infrastructure.Context;
@@ -30,11 +31,15 @@ namespace Boilerplate.Api.UnitTests
         [InlineData("e141a755-98d4-44d3-a84f-528e6e75f543")]
         public async Task GetById_existing_heroes(Guid id)
         {
+            var heroFaker = new Faker<Hero>()
+                .RuleFor(x => x.Id, f => id)
+                .RuleFor(x => x.Name, f => f.Name.FirstName())
+                .RuleFor(x => x.HeroType, f => f.PickRandom<HeroType>());
             // Arrange
 
             using (var context = CreateDbContext("GetById_existing_heroes"))
             {
-                context.Set<Hero>().Add(new Hero { Id = id });
+                context.Set<Hero>().Add(heroFaker.Generate());
                 await context.SaveChangesAsync();
             }
             Hero hero = null;
@@ -58,10 +63,14 @@ namespace Boilerplate.Api.UnitTests
         [InlineData("e141a755-98d4-44d3-a84f-528e6e75f543")]
         public async Task GetById_inexistent_heroes(Guid id)
         {
+            var heroFaker = new Faker<Hero>()
+                .RuleFor(x => x.Id, f => id)
+                .RuleFor(x => x.Name, f => f.Name.FirstName())
+                .RuleFor(x => x.HeroType, f => f.PickRandom<HeroType>());
             // Arrange
             using (var context = CreateDbContext("GetById_inexisting_heroes"))
             {
-                context.Set<Hero>().Add(new Hero { Id = id });
+                context.Set<Hero>().Add(heroFaker.Generate());
                 await context.SaveChangesAsync();
             }
             Hero hero = null;
@@ -82,10 +91,14 @@ namespace Boilerplate.Api.UnitTests
         [InlineData(5)]
         public async Task GetAll_heroes(int count)
         {
+            var heroFaker = new Faker<Hero>()
+                .RuleFor(x => x.Id, f => Guid.NewGuid())
+                .RuleFor(x => x.Name, f => f.Name.FirstName())
+                .RuleFor(x => x.HeroType, f => f.PickRandom<HeroType>());
             // Arrange
             using (var context = CreateDbContext($"GetAll_with_heroes_{count}"))
             {
-                for (var i = 0; i < count; i++) context.Set<Hero>().Add(new Hero());
+                for (var i = 0; i < count; i++) context.Set<Hero>().Add(heroFaker.Generate());
                 await context.SaveChangesAsync();
             }
             List<Hero> heroes = null;

--- a/translations/pt-br/README.md
+++ b/translations/pt-br/README.md
@@ -34,6 +34,18 @@ Isso criará o certificado https.
 Na pasta raiz, execute ``dotnet test``. Este comando tentará encontrar todos os porjetos associados ao arquivo da solução.
 Se você estiver utilizando o Visual Studio, você também pode acessar o menu "Test" e abrir o "Test Explorer", onde é possível executar todos os testes ou algum específico.
 
+## Autenticação
+Neste projeto, algumas rotas precisam de autenticação/autorização. Para isso, você terá que utilizar a rota ``api/user/authenticate`` para obter o JWT.
+Por padrão, você tem dois usuários disponíveis para login:
+- Usuário normal: 
+	- email: user@boilerplate.com
+	- senha: userpassword
+- Admin:
+	- email: admin@boilerplate.com
+	- senha: adminpassword
+
+Depois disso, você pode passar o JWT clicando no cadeado (se estiver usando swagger) ou via o cabeçalho `Authorization` se tiver realizando uma requisição http.
+
 # Este projeto contém:
 - SwaggerUI
 - EntityFramework


### PR DESCRIPTION
Relating to issue #25,

- This PR upgrades the dotnet version of the projects to 6.
- Tests are now using bogus for fake data generation.
- Github actions no longer builds when only markdown files are updated.
