### PR TITLE
FEAT: Improve CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
+        
+concurrency:
+  group: ${{ github.head_ref || github.sha }}
+  cancel-in-progress: true        
+
 env:
   GITHUB_WORKSPACE: ${{ github.workspace }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
@@ -36,6 +41,13 @@ jobs:
       - name: Install coverlet
         run: |
           dotnet tool install -g coverlet.console
+          
+      - name: Cache NuGet Packages
+        uses: actions/cache@v3
+        with:
+          key: nuget-${{ hashFiles('Directory.Build.props') }}
+          path: ~/.nuget/packages
+          
       - name: Build the project, run all tests and publish to SonarCloud
         run: |
           dotnet sonarscanner begin \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache NuGet Packages
         uses: actions/cache@v3
         with:
-          key: nuget-${{ hashFiles('Directory.Build.props') }}
+          key: nuget-${{ hashFiles('Directory.Packages.props') }}
           path: ~/.nuget/packages
           
       - name: Build the project, run all tests and publish to SonarCloud

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  analyze:
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ csharp ]
+
+    permissions:
+      security-events: write
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,6 @@ jobs:
       matrix:
         language: [ csharp ]
 
-    permissions:
-      security-events: write
-
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
1. Add cache to nuget packages
2. Remove build concurrency
3. Get codeql back